### PR TITLE
Make alb ingress class default

### DIFF
--- a/aws/config/aws-load-balancer-controller/values.yaml
+++ b/aws/config/aws-load-balancer-controller/values.yaml
@@ -1,0 +1,2 @@
+ingressClassConfig:
+  default: true


### PR DESCRIPTION
This removes the need to specifiy the annotation kubernetes.io/ingress.class: alb on your ingresses. It should be OK to have the default, because we deploy only one ingress controller.