### PR TITLE
add label selectors for all bws apps

### DIFF
--- a/bws-talos/applicationsets/argo-cd.yaml
+++ b/bws-talos/applicationsets/argo-cd.yaml
@@ -19,6 +19,11 @@ spec:
                 addonChartVersion:  8.0.17
                 addonChartRepositoryNamespace: argocd
                 addonChartRepository: https://argoproj.github.io/argo-helm
+              selector:
+                matchExpressions:
+                  - key: enable_argocd
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/cert-manager-issuers.yaml
+++ b/bws-talos/applicationsets/cert-manager-issuers.yaml
@@ -16,6 +16,11 @@ spec:
                 addonChart: cert-manager-issuers
                 addonChartVersion: main
                 addonChartRepository: https://github.com/valiton-k8s-blueprints/charts.git
+              selector:
+                matchExpressions:
+                  - key: enable_cert_manager
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/cert-manager.yaml
+++ b/bws-talos/applicationsets/cert-manager.yaml
@@ -17,6 +17,11 @@ spec:
                 addonChart: cert-manager
                 addonChartVersion: 1.17.1
                 addonChartRepository: https://charts.jetstack.io
+              selector:
+                matchExpressions:
+                  - key: enable_cert_manager
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/designate-certmanager-webhook.yaml
+++ b/bws-talos/applicationsets/designate-certmanager-webhook.yaml
@@ -17,6 +17,11 @@ spec:
                 addonChart: designate-certmanager-webhook
                 addonChartVersion: v0.1.2
                 addonChartRepository: ghcr.io/stackitcloud/charts
+              selector:
+                matchExpressions:
+                  - key: enable_cert_manager
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/external-dns.yaml
+++ b/bws-talos/applicationsets/external-dns.yaml
@@ -18,6 +18,11 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 1.16.1
                 addonChartRepository: https://kubernetes-sigs.github.io/external-dns
+              selector:
+                matchExpressions:
+                  - key: enable_external_dns
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/external-secrets-openstack-credentials.yaml
+++ b/bws-talos/applicationsets/external-secrets-openstack-credentials.yaml
@@ -17,6 +17,11 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: main
                 addonChartRepository: https://github.com/valiton-k8s-blueprints/charts.git
+              selector:
+                matchExpressions:
+                  - key: enable_external_secrets
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/external-secrets.yaml
+++ b/bws-talos/applicationsets/external-secrets.yaml
@@ -18,6 +18,11 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 0.18.1
                 addonChartRepository: https://charts.external-secrets.io
+              selector:
+                matchExpressions:
+                  - key: enable_external_secrets
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/ingress-nginx.yaml
+++ b/bws-talos/applicationsets/ingress-nginx.yaml
@@ -18,6 +18,11 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 4.12.1
                 addonChartRepository: https://kubernetes.github.io/ingress-nginx
+              selector:
+                matchExpressions:
+                  - key: enable_ingress_nginx
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/k8s-keystone-auth.yaml
+++ b/bws-talos/applicationsets/k8s-keystone-auth.yaml
@@ -8,7 +8,12 @@ spec:
   syncPolicy:
     preserveResourcesOnDeletion: true
   generators:
-    - clusters: {}
+    - clusters:
+        selector:
+          matchExpressions:
+            - key: enable_keystone_auth
+              operator: In
+              values: ['true']
   template:
     metadata:
       name: k8s-keystone-auth

--- a/bws-talos/applicationsets/kube-prometheus-stack.yaml
+++ b/bws-talos/applicationsets/kube-prometheus-stack.yaml
@@ -18,6 +18,11 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 70.0.3
                 addonChartRepository: https://prometheus-community.github.io/helm-charts
+              selector:
+                matchExpressions:
+                  - key: enable_kube_prometheus_stack
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/kubelet-serving-cert-approver.yaml
+++ b/bws-talos/applicationsets/kubelet-serving-cert-approver.yaml
@@ -8,7 +8,12 @@ spec:
   syncPolicy:
     preserveResourcesOnDeletion: true
   generators:
-    - clusters: {}
+    - clusters:
+        selector:
+          matchExpressions:
+            - key: enable_cert_manager
+              operator: In
+              values: ['true']
   template:
     metadata:
       name: kubelet-serving-cert-approver

--- a/bws-talos/applicationsets/metrics-server.yaml
+++ b/bws-talos/applicationsets/metrics-server.yaml
@@ -19,6 +19,11 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 3.12.0
                 addonChartRepository: https://kubernetes-sigs.github.io/metrics-server
+              selector:
+                matchExpressions:
+                  - key: enable_metrics_server
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/openstack-cinder-csi.yaml
+++ b/bws-talos/applicationsets/openstack-cinder-csi.yaml
@@ -17,6 +17,11 @@ spec:
                 addonChart: openstack-cinder-csi
                 addonChartRepository: https://kubernetes.github.io/cloud-provider-openstack
                 addonChartVersion: 2.32.0
+              selector:
+                matchExpressions:
+                  - key: enable_openstack_cinder_csi
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/bws-talos/applicationsets/openstack-cloud-controller-manager.yaml
+++ b/bws-talos/applicationsets/openstack-cloud-controller-manager.yaml
@@ -17,6 +17,11 @@ spec:
                 addonChart: openstack-cloud-controller-manager
                 addonChartRepository: https://kubernetes.github.io/cloud-provider-openstack
                 addonChartVersion: 2.32.0
+              selector:
+                matchExpressions:
+                  - key: enable_cloud_controller_manager
+                    operator: In
+                    values: ['true']
           - clusters:
               selector:
                 matchLabels:


### PR DESCRIPTION
As shown in https://github.com/valiton-k8s-blueprints/terraform/pull/15, we are adding label selectors also for BWS applications which are for now deployed all out of the box. This is now unified to the other cloud provider implementations. 