### PR TITLE
Add loki logging

### DIFF
--- a/aws/applicationsets/fluent-bit.yaml
+++ b/aws/applicationsets/fluent-bit.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: fluent-bit
+  namespace: argocd
+spec:
+  goTemplate: true
+  syncPolicy:
+    preserveResourcesOnDeletion: false
+  generators:
+    - clusters:
+        selector:
+          matchExpressions:
+            - key: enable_logging
+              operator: In
+              values: ['true']
+  template:
+    metadata:
+      name: 'fluent-bit'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io/background
+    spec:
+      project: default
+      sources:
+        - repoURL: '{{.metadata.annotations.applications_repo_url}}'
+          targetRevision: '{{.metadata.annotations.applications_repo_revision}}'
+          ref: values
+        - chart: 'fluent-bit'
+          repoURL: 'https://fluent.github.io/helm-charts'
+          targetRevision: '0.51.0'
+          helm:
+            releaseName: 'fluent-bit'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              - $values/{{.metadata.annotations.applications_repo_path}}/config/fluent-bit/values.yaml
+              - $values/{{.metadata.annotations.applications_repo_path}}/config/fluent-bit/{{.metadata.labels.environment}}.yaml
+      destination:
+        namespace: 'fluent-bit'
+        name: '{{.name}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+      ignoreDifferences:
+        - group: admissionregistration.k8s.io
+          kind: MutatingWebhookConfiguration
+          jqPathExpressions: ['.webhooks[].clientConfig.caBundle']
+        - group: admissionregistration.k8s.io
+          kind: ValidatingWebhookConfiguration
+          jqPathExpressions: ['.webhooks[].clientConfig.caBundle']

--- a/aws/applicationsets/fluent-bit.yaml
+++ b/aws/applicationsets/fluent-bit.yaml
@@ -18,11 +18,6 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 0.51.0
                 addonChartRepository: https://fluent.github.io/helm-charts
-              selector:
-                matchExpressions:
-                  - key: enable_logging
-                    operator: In
-                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/aws/applicationsets/fluent-bit.yaml
+++ b/aws/applicationsets/fluent-bit.yaml
@@ -9,12 +9,32 @@ spec:
   syncPolicy:
     preserveResourcesOnDeletion: false
   generators:
-    - clusters:
-        selector:
-          matchExpressions:
-            - key: enable_logging
-              operator: In
-              values: ['true']
+    - merge:
+        mergeKeys: [server]
+        generators:
+          - clusters:
+              values:
+                addonChart: fluent-bit
+                # anything not staging or prod use this version
+                addonChartVersion: 0.51.0
+                addonChartRepository: https://fluent.github.io/helm-charts
+              selector:
+                matchExpressions:
+                  - key: enable_logging
+                    operator: In
+                    values: ['true']
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: staging
+              values:
+                addonChartVersion: 0.51.0
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: production
+              values:
+                addonChartVersion: 0.51.0
   template:
     metadata:
       name: 'fluent-bit'
@@ -26,11 +46,11 @@ spec:
         - repoURL: '{{.metadata.annotations.applications_repo_url}}'
           targetRevision: '{{.metadata.annotations.applications_repo_revision}}'
           ref: values
-        - chart: 'fluent-bit'
-          repoURL: 'https://fluent.github.io/helm-charts'
-          targetRevision: '0.51.0'
+        - chart: '{{.values.addonChart}}'
+          repoURL: '{{.values.addonChartRepository}}'
+          targetRevision: '{{.values.addonChartVersion}}'
           helm:
-            releaseName: 'fluent-bit'
+            releaseName: '{{.values.addonChart}}'
             ignoreMissingValueFiles: true
             valueFiles:
               - $values/{{.metadata.annotations.applications_repo_path}}/config/fluent-bit/values.yaml

--- a/aws/applicationsets/loki.yaml
+++ b/aws/applicationsets/loki.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: loki
+  namespace: argocd
+spec:
+  goTemplate: true
+  syncPolicy:
+    preserveResourcesOnDeletion: false
+  generators:
+    - clusters:
+        selector:
+          matchExpressions:
+            - key: enable_logging
+              operator: In
+              values: ['true']
+  template:
+    metadata:
+      name: 'loki'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io/background
+    spec:
+      project: default
+      sources:
+        - repoURL: '{{.metadata.annotations.applications_repo_url}}'
+          targetRevision: '{{.metadata.annotations.applications_repo_revision}}'
+          ref: values
+        - chart: 'loki'
+          repoURL: 'https://grafana.github.io/helm-charts'
+          targetRevision: '6.39.0'
+          helm:
+            releaseName: 'loki'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              - $values/{{.metadata.annotations.applications_repo_path}}/config/loki/values.yaml
+              - $values/{{.metadata.annotations.applications_repo_path}}/config/loki/{{.metadata.labels.environment}}.yaml
+      destination:
+        namespace: 'loki'
+        name: '{{.name}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+      ignoreDifferences:
+        - group: admissionregistration.k8s.io
+          kind: MutatingWebhookConfiguration
+          jqPathExpressions: ['.webhooks[].clientConfig.caBundle']
+        - group: admissionregistration.k8s.io
+          kind: ValidatingWebhookConfiguration
+          jqPathExpressions: ['.webhooks[].clientConfig.caBundle']

--- a/aws/applicationsets/loki.yaml
+++ b/aws/applicationsets/loki.yaml
@@ -18,11 +18,6 @@ spec:
                 # anything not staging or prod use this version
                 addonChartVersion: 6.39.0
                 addonChartRepository: https://grafana.github.io/helm-charts
-              selector:
-                matchExpressions:
-                  - key: enable_logging
-                    operator: In
-                    values: ['true']
           - clusters:
               selector:
                 matchLabels:

--- a/aws/applicationsets/loki.yaml
+++ b/aws/applicationsets/loki.yaml
@@ -9,12 +9,32 @@ spec:
   syncPolicy:
     preserveResourcesOnDeletion: false
   generators:
-    - clusters:
-        selector:
-          matchExpressions:
-            - key: enable_logging
-              operator: In
-              values: ['true']
+    - merge:
+        mergeKeys: [server]
+        generators:
+          - clusters:
+              values:
+                addonChart: loki
+                # anything not staging or prod use this version
+                addonChartVersion: 6.39.0
+                addonChartRepository: https://grafana.github.io/helm-charts
+              selector:
+                matchExpressions:
+                  - key: enable_logging
+                    operator: In
+                    values: ['true']
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: staging
+              values:
+                addonChartVersion: 6.39.0
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: production
+              values:
+                addonChartVersion: 6.39.0
   template:
     metadata:
       name: 'loki'
@@ -26,11 +46,11 @@ spec:
         - repoURL: '{{.metadata.annotations.applications_repo_url}}'
           targetRevision: '{{.metadata.annotations.applications_repo_revision}}'
           ref: values
-        - chart: 'loki'
-          repoURL: 'https://grafana.github.io/helm-charts'
-          targetRevision: '6.39.0'
+        - chart: '{{.values.addonChart}}'
+          repoURL: '{{.values.addonChartRepository}}'
+          targetRevision: '{{.values.addonChartVersion}}'
           helm:
-            releaseName: 'loki'
+            releaseName: '{{.values.addonChart}}'
             ignoreMissingValueFiles: true
             valueFiles:
               - $values/{{.metadata.annotations.applications_repo_path}}/config/loki/values.yaml

--- a/aws/config/fluent-bit/values.yaml
+++ b/aws/config/fluent-bit/values.yaml
@@ -1,0 +1,25 @@
+config:
+  inputs: |
+    [INPUT]
+        Name              tail
+        Path              /var/log/containers/*.log
+        Parser            docker
+        Tag               kube.*
+        Refresh_Interval  5
+        Mem_Buf_Limit     50MB
+        Skip_Long_Lines   On
+  filters: |
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+  outputs: |
+    [OUTPUT]
+        Name loki
+        Match kube.*
+        Host loki.loki.svc.cluster.local
+        Port 3100
+        Labels job=fluentbit,namespace=$kubernetes['namespace_name'],pod=$kubernetes['pod_name'],container=$kubernetes['container_name']

--- a/aws/config/kube-prometheus-stack/values.yaml
+++ b/aws/config/kube-prometheus-stack/values.yaml
@@ -1,0 +1,15 @@
+grafana:
+  sidecar:
+    datasources:
+      enabled: true
+      label: grafana_datasource
+
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          url: http://loki.loki.svc.cluster.local:3100
+          isDefault: false

--- a/aws/config/loki/values.yaml
+++ b/aws/config/loki/values.yaml
@@ -1,0 +1,88 @@
+loki:
+  # Required for template compatibility even in SingleBinary mode
+  storage:
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+    type: filesystem
+    filesystem:
+      chunks_directory: /var/loki/chunks
+      rules_directory: /var/loki/rules
+  
+  # Add common config to satisfy validation
+  commonConfig:
+    replication_factor: 1
+    
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+
+  storage_config:
+    tsdb_shipper:
+      active_index_directory: /var/loki/tsdb-index
+    filesystem:
+      directory: /var/loki/chunks
+
+  # Configure rings to use memberlist instead of consul
+  ingester:
+    lifecycler:
+      ring:
+        kvstore:
+          store: memberlist
+        
+  ruler:
+    ring:
+      kvstore:
+        store: memberlist
+    storage:
+      type: local
+      local:
+        directory: /var/loki/rules
+        
+  query_scheduler:
+    scheduler_ring:
+      kvstore:
+        store: memberlist
+        
+  limits_config:
+    retention_period: 168h  # 7 days
+
+deploymentMode: SingleBinary
+
+singleBinary:
+  resources:
+    limits:
+      cpu: 1
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  persistence:
+    enabled: true
+    size: 50Gi
+    storageClassName: gp3
+
+# Explicitly disable distributed components for validation
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+ingester:
+  replicas: 0
+querier:
+  replicas: 0
+queryFrontend:
+  replicas: 0
+distributor:
+  replicas: 0
+compactor:
+  replicas: 0

--- a/aws/config/loki/values.yaml
+++ b/aws/config/loki/values.yaml
@@ -1,4 +1,6 @@
 loki:
+  auth_enabled: false
+  
   # Required for template compatibility even in SingleBinary mode
   storage:
     bucketNames:


### PR DESCRIPTION
Adds two new applicationsets for logging (can be activated using `enable_logging` cluster annotation): 
- `fluent-bit`
- `loki`

Loki is for now saving the result locally on an EBS volume (better way to do it with S3 but for now fine to get started and I think sufficient for 90% of the cases). The loki data source is also automatically created within Grafana: 

<img width="1886" height="988" alt="image" src="https://github.com/user-attachments/assets/c54e1a00-5826-4d05-b029-c59ee37ee80f" />

> Important: it is for now only made for `AWS` as I was missing time to also implement it for the others - feel free to extend it for others in case you want to keep it for the blueprint

Related PR: https://github.com/valiton-k8s-blueprints/terraform/pull/21